### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -1,5 +1,7 @@
 name: GitHub Actions Demo
 run-name: ${{ github.actor }} is testing out GitHub Actions 🚀
+permissions:
+  contents: read
 on: [push]
 jobs:
   Explore-GitHub-Actions:


### PR DESCRIPTION
Potential fix for [https://github.com/DarrenFriel/DemoDF/security/code-scanning/2](https://github.com/DarrenFriel/DemoDF/security/code-scanning/2)

To fix this issue, we should add a `permissions` key to the workflow, specifying the least privileges needed for the actions performed. In this demo workflow, all steps are read-only (printing information, checking out code, listing files). The minimal required permission is `contents: read`, which enables checking out the repository code but does not allow write operations. The `permissions` block can be added at the root of the workflow file, so it applies to all jobs (unless overridden). This involves adding a block right after the workflow’s name and run-name, i.e., before the `on:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
